### PR TITLE
2.2

### DIFF
--- a/resources/views/dropdown.twig
+++ b/resources/views/dropdown.twig
@@ -8,13 +8,19 @@
         <option value="">{{ trans(field_type.placeholder) }}</option>
     {% endif %}
 
-    {% for value, option in field_type.options %}
-        {% if option is iterable %}Test
-            <optgroup label="{{ value }}">
+    {% set fieldTypeOptions = field_type.options %}
+
+    {% for value, option in fieldTypeOptions %}
+        {% if option is iterable %}
+            {% if fieldTypeOptions|length > 1 %}
+                <optgroup label="{{ value }}">
+            {% endif %}
                 {% for value, option in option %}
                     <option value="{{ value }}" {{ value == field_type.value ? 'selected' }}>{{ trans(option) }}</option>
                 {% endfor %}
-            </optgroup>
+            {% if fieldTypeOptions|length > 1 %}
+                </optgroup>
+            {% endif %}
         {% else %}
             <option value="{{ value }}" {{ value == field_type.value ? 'selected' }}>{{ trans(option) }}</option>
         {% endif %}

--- a/resources/views/dropdown.twig
+++ b/resources/views/dropdown.twig
@@ -12,13 +12,13 @@
 
     {% for value, option in fieldTypeOptions %}
         {% if option is iterable %}
-            {% if fieldTypeOptions|length > 1 %}
+            {% if (fieldTypeOptions|length) != 1 %}
                 <optgroup label="{{ value }}">
             {% endif %}
                 {% for value, option in option %}
                     <option value="{{ value }}" {{ value == field_type.value ? 'selected' }}>{{ trans(option) }}</option>
                 {% endfor %}
-            {% if fieldTypeOptions|length > 1 %}
+            {% if (fieldTypeOptions|length) != 1 %}
                 </optgroup>
             {% endif %}
         {% else %}

--- a/resources/views/filter.twig
+++ b/resources/views/filter.twig
@@ -2,13 +2,19 @@
 
     <option value="">{{ trans(field_type.placeholder) }}</option>
 
-    {% for value, option in field_type.options %}
-        {% if option is iterable %}Test
-            <optgroup label="{{ value }}">
+    {% set fieldTypeOptions = field_type.options %}
+
+    {% for value, option in fieldTypeOptions %}
+        {% if option is iterable %}
+            {% if fieldTypeOptions|length > 1 %}
+                <optgroup label="{{ value }}">
+            {% endif %}
                 {% for value, option in option %}
                     <option value="{{ value }}" {{ value == field_type.value ? 'selected' }}>{{ trans(option) }}</option>
                 {% endfor %}
-            </optgroup>
+            {% if fieldTypeOptions|length > 1 %}
+                </optgroup>
+            {% endif %}
         {% else %}
             <option value="{{ value }}" {{ value == field_type.value ? 'selected' }}>{{ trans(option) }}</option>
         {% endif %}

--- a/resources/views/filter.twig
+++ b/resources/views/filter.twig
@@ -6,13 +6,13 @@
 
     {% for value, option in fieldTypeOptions %}
         {% if option is iterable %}
-            {% if fieldTypeOptions|length > 1 %}
+            {% if (fieldTypeOptions|length) != 1 %}
                 <optgroup label="{{ value }}">
             {% endif %}
                 {% for value, option in option %}
                     <option value="{{ value }}" {{ value == field_type.value ? 'selected' }}>{{ trans(option) }}</option>
                 {% endfor %}
-            {% if fieldTypeOptions|length > 1 %}
+            {% if (fieldTypeOptions|length) != 1 %}
                 </optgroup>
             {% endif %}
         {% else %}

--- a/resources/views/search.twig
+++ b/resources/views/search.twig
@@ -17,13 +17,13 @@
 
     {% for value, option in fieldTypeOptions %}
         {% if option is iterable %}
-            {% if fieldTypeOptions|length > 1 %}
+            {% if (fieldTypeOptions|length) != 1 %}
                 <optgroup label="{{ value }}">
             {% endif %}
                 {% for value, option in option %}
                     <option value="{{ value }}" {{ value == field_type.value ? 'selected' }}>{{ trans(option) }}</option>
                 {% endfor %}
-            {% if fieldTypeOptions|length > 1 %}
+            {% if (fieldTypeOptions|length) != 1 %}
                 </optgroup>
             {% endif %}
         {% else %}

--- a/resources/views/search.twig
+++ b/resources/views/search.twig
@@ -13,13 +13,19 @@
         <option value="">{{ trans(field_type.placeholder) }}</option>
     {% endif %}
 
-    {% for value, option in field_type.options %}
-        {% if option is iterable %}Test
-            <optgroup label="{{ value }}">
+    {% set fieldTypeOptions = field_type.options %}
+
+    {% for value, option in fieldTypeOptions %}
+        {% if option is iterable %}
+            {% if fieldTypeOptions|length > 1 %}
+                <optgroup label="{{ value }}">
+            {% endif %}
                 {% for value, option in option %}
                     <option value="{{ value }}" {{ value == field_type.value ? 'selected' }}>{{ trans(option) }}</option>
                 {% endfor %}
-            </optgroup>
+            {% if fieldTypeOptions|length > 1 %}
+                </optgroup>
+            {% endif %}
         {% else %}
             <option value="{{ value }}" {{ value == field_type.value ? 'selected' }}>{{ trans(option) }}</option>
         {% endif %}


### PR DESCRIPTION
@RyanThompson - not sure what your thoughts are on this but i think the majority of use cases for a state field type will be one country.  In these cases i don't think an optgroup make sense.  This patch removes opt groups if there is only 1 country selected.

This is easy to override so not really an issue for me if this is in core or not but thought it might be a common enough issue to warrant making it core functionality.